### PR TITLE
Fix detect and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,13 @@ The Paketo Clojure Tools Buildpack is a Cloud Native Buildpack that builds Cloju
 ## Behavior
 This buildpack will participate all the following conditions are met
 
-* `<APPLICATION_ROOT>/build.clj` exists
 * `<APPLICATION_ROOT>/deps.edn` exists
 
 The buildpack will do the following:
 
 * Requests that a JDK be installed
 * Links the `~/.m2` to a layer for caching
-* If `<APPLICATION_ROOT>/build.clj` does not exist
-  * Contributes Clojure Tools to a layer with all commands on `$PATH`
-  * Runs `<CLOJURE_TOOLS_ROOT>/clojure -T:build uber` to build the application
-* If `<APPLICATION_ROOT>/deps.edn` does not exist
+* If `<APPLICATION_ROOT>/deps.edn` exists
   * Contributes Clojure Tools to a layer with all commands on `$PATH`
   * Runs `<CLOJURE_TOOLS_ROOT>/clojure -X:uberjar` to build the application
 * Removes the source code in `<APPLICATION_ROOT>`
@@ -24,6 +20,7 @@ The buildpack will do the following:
 ## Configuration
 | Environment Variable | Description
 | -------------------- | -----------
+| `$BP_CLJ_TOOLS_BUILD_ENABLED` | Configure the arguments to enable tools build.
 | `$BP_CLJ_TOOLS_BUILD_ARGUMENTS` | Configure the arguments to pass to build system.  Defaults to `-T:build uber`.
 | `$BP_CLJ_DEPS_ARGUMENTS` | Configure the arguments to pass to build system.  Defaults to `-X:uberjar`.
 | `$BP_CLJ_BUILT_MODULE` | Configure the module to find application artifact in.  Defaults to the root module (empty).

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -42,6 +42,12 @@ default     = "-X:uberjar"
 build       = true
 
 [[metadata.configurations]]
+name        = "BP_CLJ_TOOLS_BUILD_ENABLED"
+description = "the arguments to enable Tools Build"
+default     = "false"
+build       = true
+
+[[metadata.configurations]]
 name        = "BP_CLJ_TOOLS_BUILD_ARGUMENTS"
 description = "the arguments to pass to Tools Build"
 default     = "-T:build uber"

--- a/clojure/build.go
+++ b/clojure/build.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/libbs"
@@ -88,13 +89,15 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	c.Logger = b.Logger
 	result.Layers = append(result.Layers, c)
 
+	ednFileExists := fileExists(filepath.Join(context.Application.Path, "deps.edn"))
+	toolsBuildEnabled, err := libbs.ResolveArguments("BP_CLJ_TOOLS_BUILD_ENABLED", cr)
 	var args []string
-	if fileExists(filepath.Join(context.Application.Path, "build.clj")) {
+	if ednFileExists && strings.ToLower(toolsBuildEnabled[0]) == "true" {
 		args, err = libbs.ResolveArguments("BP_CLJ_TOOLS_BUILD_ARGUMENTS", cr)
 		if err != nil {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to resolve build arguments\n%w", err)
 		}
-	} else if fileExists(filepath.Join(context.Application.Path, "deps.edn")) {
+	} else if ednFileExists {
 		args, err = libbs.ResolveArguments("BP_CLJ_DEPS_ARGUMENTS", cr)
 		if err != nil {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to resolve build arguments\n%w", err)

--- a/clojure/detect.go
+++ b/clojure/detect.go
@@ -33,35 +33,28 @@ const (
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
-	files := []string{
-		filepath.Join(context.Application.Path, "deps.edn"),
-		filepath.Join(context.Application.Path, "build.clj"),
+	file := filepath.Join(context.Application.Path, "deps.edn")
+
+	_, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		return libcnb.DetectResult{Pass: false}, nil
+	} else if err != nil {
+		return libcnb.DetectResult{}, fmt.Errorf("unable to determine if %s exists\n%w", file, err)
 	}
 
-	for _, file := range files {
-		_, err := os.Stat(file)
-		if os.IsNotExist(err) {
-			continue
-		} else if err != nil {
-			return libcnb.DetectResult{}, fmt.Errorf("unable to determine if %s exists\n%w", file, err)
-		}
-
-		return libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: PlanEntryClj},
-						{Name: PlanEntryJVMApplicationPackage},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: PlanEntryClj},
-						{Name: PlanEntryJDK},
-					},
+	return libcnb.DetectResult{
+		Pass: true,
+		Plans: []libcnb.BuildPlan{
+			{
+				Provides: []libcnb.BuildPlanProvide{
+					{Name: PlanEntryClj},
+					{Name: PlanEntryJVMApplicationPackage},
+				},
+				Requires: []libcnb.BuildPlanRequire{
+					{Name: PlanEntryClj},
+					{Name: PlanEntryJDK},
 				},
 			},
-		}, nil
-	}
-
-	return libcnb.DetectResult{Pass: false}, nil
+		},
+	}, nil
 }

--- a/clojure/detect_test.go
+++ b/clojure/detect_test.go
@@ -71,28 +71,4 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			},
 		}))
 	})
-
-	it("fails without build.clj", func() {
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
-	})
-
-	it("passes with build.clj", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "build.clj"), []byte{}, 0644))
-
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "clojure"},
-						{Name: "jvm-application-package"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "clojure"},
-						{Name: "jdk"},
-					},
-				},
-			},
-		}))
-	})
 }


### PR DESCRIPTION
Currently, `detect` phase is based if `deps.edn` or `build.clj`
exists on the root directory. However, `build.clj` location is
defined on `deps.edn` file. So, if `deps.edn` file is present
is enough for detection.

Also, argument `BP_CLJ_TOOLS_BUILD_ENABLED` is added with value
`false`. If it is ser to `true` then the right command will be
executed.
