### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/clojure-tools`
 
-The Paketo Clojure Tools Buildpack is a Cloud Native Buildpack that builds Clojure-based applications from source.
+The Paketo Buildpack for Clojure Tools is a Cloud Native Buildpack that builds Clojure-based applications from source.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/clojure-tools"
   id = "paketo-buildpacks/clojure-tools"
   keywords = ["java", "clojure", "build-system"]
-  name = "Paketo Clojure Tools Buildpack"
+  name = "Paketo Buildpack for Clojure Tools"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Clojure Tools Buildpack' to 'Paketo Buildpack for Clojure Tools'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
