### PR TITLE
Do not use effect.NewExecutor use CommandExecutor instead

### DIFF
--- a/clojure/build.go
+++ b/clojure/build.go
@@ -93,7 +93,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result.Layers = append(result.Layers, c)
 
 	ednFileExists := fileExists(filepath.Join(context.Application.Path, "deps.edn"))
-	toolsBuildEnabled, err := libbs.ResolveArguments("BP_CLJ_TOOLS_BUILD_ENABLED", cr)
+	toolsBuildEnabled, _ := libbs.ResolveArguments("BP_CLJ_TOOLS_BUILD_ENABLED", cr)
 	var args []string
 	if ednFileExists && strings.ToLower(toolsBuildEnabled[0]) == "true" {
 		args, err = libbs.ResolveArguments("BP_CLJ_TOOLS_BUILD_ARGUMENTS", cr)
@@ -114,7 +114,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		InterestingFileDetector:  libbs.AlwaysInterestingFileDetector{},
 	}
 
-	sbomScanner := sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
+	sbomScanner := sbom.NewSyftCLISBOMScanner(context.Layers, effect.CommandExecutor{}, b.Logger)
 
 	a, err := b.ApplicationFactory.NewApplication(
 		map[string]interface{}{},

--- a/clojure/build_test.go
+++ b/clojure/build_test.go
@@ -17,7 +17,6 @@
 package clojure_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,12 +42,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "build-application")
+		ctx.Application.Path, err = os.MkdirTemp("", "build-application")
 		Expect(err).NotTo(HaveOccurred())
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "build-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "build-layers")
 		Expect(err).NotTo(HaveOccurred())
 		clojureBuild = clojure.Build{ApplicationFactory: &FakeApplicationFactory{}}
+
+		t.Setenv("BP_ARCH", "amd64")
 	})
 
 	it.After(func() {
@@ -57,7 +58,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("does not contribute distribution if wrapper exists", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "clojure"), []byte{}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "clojure"), []byte{}, 0644)).To(Succeed())
 		ctx.StackID = "test-stack-id"
 
 		result, err := clojureBuild.Build(ctx)

--- a/clojure/detect_test.go
+++ b/clojure/detect_test.go
@@ -17,7 +17,6 @@
 package clojure_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "clojure")
+		ctx.Application.Path, err = os.MkdirTemp("", "clojure")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -53,7 +52,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("passes with deps.edn", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "deps.edn"), []byte{}, 0644))
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "deps.edn"), []byte{}, 0644))
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 			Pass: true,

--- a/clojure/distribution_test.go
+++ b/clojure/distribution_test.go
@@ -17,7 +17,6 @@
 package clojure_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +41,7 @@ func testDistribution(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(err).NotTo(HaveOccurred())
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "distribution-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "distribution-layers")
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
## Summary
When running `syft`, do not use effect.NewExecutor which runs the command with a tty. This seems to cause an issue with syft (or possibly with our tty library pty), and in either case you end up with stray formatting characters even though we tell syft to be quiet. Using CommandExecutor is basically the same, but it doesn't run with a tty.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
